### PR TITLE
Update for gl_generator's new code generation model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "glx"
 version = "0.0.1"
 authors = []
+description = "GLX 1.4 bindings"
+license = "ASL2"
+build = "src/build.rs"
 
-[dependencies.gl_generator]
+[build-dependencies.gl_generator]
 git = "https://github.com/bjz/gl-rs.git"

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,16 @@
+extern crate gl_generator;
+extern crate khronos_api;
+
+use std::os;
+use std::io::File;
+
+fn main() {
+    let dest = Path::new(os::getenv("OUT_DIR").unwrap());
+    let mut file = File::create(&dest.join("bindings.rs")).unwrap();
+    gl_generator::generate_bindings(gl_generator::StaticGenerator,
+                                    gl_generator::registry::Ns::Glx,
+                                    khronos_api::GLX_XML,
+                                    vec![ "GLX_EXT_texture_from_pixmap".to_string() ],
+                                    "1.4", "core",
+                                    &mut file).unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,23 +8,6 @@
 // except according to those terms.
 
 #![crate_name = "glx"]
-#![comment = "GLX 1.4 bindings"]
-#![license = "ASL2"]
 #![crate_type = "lib"]
 
-#![feature(phase)]
-#![feature(globs)]
-
-#[phase(plugin)]
-extern crate gl_generator;
-
-/// GLX bindings
-generate_gl_bindings! {
-    api: "glx",
-    profile: "core",
-    version: "1.4",
-    generator: "static",
-    extensions: [
-        "GLX_EXT_texture_from_pixmap"
-    ],
-}
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
This un-breaks things for gl-rs generating code with a Cargo build step rather than a macro.

It causes a lot of warnings without https://github.com/bjz/gl-rs/pull/252

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-glx/3)
<!-- Reviewable:end -->
