### PR TITLE
Update gl_generator to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glx"
-version = "0.1.2"
+version = "0.2.0"
 license = "MIT / Apache-2.0"
 authors = ["Servo developers"]
 description = "GLX 1.4 bindings for Linux"
@@ -9,7 +9,7 @@ build = "build.rs"
 repository = "https://github.com/servo/rust-glx"
 
 [build-dependencies]
-gl_generator = "0.5"
+gl_generator = "0.6"
 khronos_api = "1.0.0"
 
 [dependencies]


### PR DESCRIPTION
See servo/gleam#130. We also need this to avoid duplicated versions tidy checks to land the new gleam version in Servo.

Please, publish the new version to crates.io when merged ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-glx/17)
<!-- Reviewable:end -->
