### PR TITLE
Remove khronos_api dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glx"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT / Apache-2.0"
 authors = ["Servo developers"]
 description = "GLX 1.4 bindings for Linux"
@@ -10,7 +10,6 @@ repository = "https://github.com/servo/rust-glx"
 
 [build-dependencies]
 gl_generator = "0.6"
-khronos_api = "1.0.0"
 
 [dependencies]
 libc = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,4 @@
 extern crate gl_generator;
-extern crate khronos_api;
 
 use std::env;
 use std::fs::File;


### PR DESCRIPTION
It's not used anymore in this crate and causes tidy check failures with the Gleam update in Servo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-glx/18)
<!-- Reviewable:end -->
